### PR TITLE
Add e-mail trimming

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,7 +116,7 @@
                 false);
             xhReq.setRequestHeader("Content-Type", "application/json");
 
-            var kindleEmail = document.getElementById('email-input').value;
+            var kindleEmail = document.getElementById('email-input').value.trim();
             var requestCode = getCookie("pocketkey");
 
             var data = JSON.stringify({


### PR DESCRIPTION
When copying Kindle e-mail on some browsers (e.g. Firefox), a space is added at the beginning of the copied text.
E-mail with space at the beginning is considered invalid by back end so let's trim it before making the request.